### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Python plumbing library for building microframework-based applications.
 Rick provides essential building blocks and utilities for constructing robust, maintainable Python applications without
 imposing architectural constraints. It's lightweight, modular, and battle-tested.
 
+## Documentation
+
+Documentation is available at [https://oddbit-project.github.io/rick/](https://oddbit-project.github.io/rick/)
+
 ## Features
 
 ### Core Components
@@ -223,10 +227,6 @@ color = AnsiColor()
 print(color.red('Error:', attr='bold') + ' Operation failed')
 print(color.green('Success', 'white', ['bold', 'underline']))
 ```
-
-## Documentation
-
-Full documentation is available at [https://oddbit-project.github.io/rick/](https://oddbit-project.github.io/rick/)
 
 ## Use Cases
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rick
 
-[![Tests](https://github.com/oddbit-project/rick/workflows/Tests/badge.svg?branch=master)](https://github.com/oddbit-project/rick/actions)
+[![Tests](https://github.com/oddbit-project/rick/actions/workflows/run-tests.yml/badge.svg?branch=master)](https://github.com/oddbit-project/rick/actions/workflows/run-tests.yml)
 [![pypi](https://img.shields.io/pypi/v/rick.svg)](https://pypi.org/project/rick/)
 [![Python](https://img.shields.io/pypi/pyversions/rick.svg)](https://pypi.org/project/rick/)
 [![license](https://img.shields.io/pypi/l/rick.svg)](https://github.com/oddbit-project/rick/blob/master/LICENSE)

--- a/README.md
+++ b/README.md
@@ -226,21 +226,7 @@ print(color.green('Success', 'white', ['bold', 'underline']))
 
 ## Documentation
 
-Full documentation is available at [https://docs.rick.oddbit.org](https://github.com/oddbit-project/rick)
-
-### Key Documentation Sections
-
-- **[Forms & Validation](https://github.com/oddbit-project/rick/blob/master/docs/forms/index.md)** - Request
-  validation and form processing
-- **[Validators](https://github.com/oddbit-project/rick/blob/master/docs/validators/index.md)** - Available validation
-  rules
-- **[Serializers](https://github.com/oddbit-project/rick/blob/master/docs/serializers/index.md)** - JSON and
-  MessagePack serialization
-- **[Configuration](https://github.com/oddbit-project/rick/blob/master/docs/resources/config.md)** - Configuration
-  management
-- **[Redis Cache](https://github.com/oddbit-project/rick/blob/master/docs/resources/redis.md)** - Caching with Redis
-- **[Console Output](https://github.com/oddbit-project/rick/blob/master/docs/resources/console.md)** - Colored console
-  output
+Full documentation is available at [https://oddbit-project.github.io/rick/](https://oddbit-project.github.io/rick/)
 
 ## Use Cases
 
@@ -377,3 +363,4 @@ See [CHANGELOG.md](CHANGELOG.md) for version history and release notes.
 - **Issues**: [GitHub Issues](https://github.com/oddbit-project/rick/issues)
 - **Repository**: [GitHub](https://github.com/oddbit-project/rick)
 - **PyPI**: [https://pypi.org/project/rick/](https://pypi.org/project/rick/)
+- **Documentation**: [https://oddbit-project.github.io/rick/](https://oddbit-project.github.io/rick/)


### PR DESCRIPTION
## Summary by Sourcery

Update README by adjusting test badge URL and streamlining documentation links.

CI:
- Point the tests badge in README to the new GitHub Actions workflow file.

Documentation:
- Replace detailed documentation section with a concise link to the hosted docs site and add the link to the bottom navigation.