### PR TITLE
v0.8.2: security hardening and bug fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes to the [Rick](https://github.com/oddbit-project/rick) projec
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.8.2]
+
+### Fixed
+- RequestRecord: field value assignment now occurs before custom validator execution, ensuring validators have access to the field value
+- RequestRecord: record-level errors now take precedence over validator errors when merging
+- CryptRedisCache: key validation now checks byte length instead of string length for correct multi-byte handling
+- EventManager: dispatch() now uses try/finally to prevent stack leak on handler exceptions
+- EventManager: wakeup() now uses deepcopy to prevent unintended state mutation
+- Di: cache_clear() is now performed inside a lock to prevent race conditions with concurrent access
+- MapLoader: cache_clear() moved inside lock block; get() now uses try/finally to prevent stack leak on import errors
+- BcryptHasher: removed unnecessary SHA-256 pre-hashing; passwords are now hashed directly with bcrypt
+- sha1_hash(): now emits DeprecationWarning; SHA-1 is cryptographically broken
+- hash_buffer(): restricted to approved algorithms (sha256, sha384, sha512, blake2b, blake2s); raises ValueError for unapproved algorithms
+- MultiPartReader: added bounds clamping to prevent reading past stream end
+- Between validator: now properly calls parse_options() for default handling
+- ListLen validator: added null check for missing options
+- Decimal validator: now rejects Infinity and NaN values
+- Email validator: added RFC 5321 length limits (64-char user, 255-char domain) and empty user check
+- IntRule validator: now rejects Python booleans
+- FQDN validator: removed localhost from whitelist
+- is_object(): replaced fragile type detection with explicit isinstance checks
+- msgpack unpackb(): added depth-limited deserialization (max depth 32) to prevent stack overflow from crafted payloads
+- iso8601_now(): now uses explicit datetime.timezone.utc instead of deprecated utcnow()
+- Form Control/FieldSet: fixed shared mutable default attributes and NameError in duplicate field check
+
 ## [0.8.1]
 
 ### Added
@@ -176,7 +201,9 @@ Version bump release.
 - Injectable mixin
 - Validator framework with string, numeric, network, hash, and misc validators
 
-[Unreleased]: https://github.com/oddbit-project/rick/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/oddbit-project/rick/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/oddbit-project/rick/compare/v0.8.1...v0.8.2
+[0.8.1]: https://github.com/oddbit-project/rick/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/oddbit-project/rick/compare/0.7.1...v0.8.0
 [0.7.1]: https://github.com/oddbit-project/rick/compare/0.7.0...0.7.1
 [0.7.0]: https://github.com/oddbit-project/rick/compare/0.6.9...0.7.0

--- a/docs/crypto/bcrypt.md
+++ b/docs/crypto/bcrypt.md
@@ -117,7 +117,7 @@ Hash a password using bcrypt.
 pw_hash = hasher.hash("my_secure_password")
 ```
 
-**Note:** The password is first hashed with SHA-256 before bcrypt to handle passwords longer than 72 bytes.
+**Note:** Passwords longer than 72 bytes are truncated by bcrypt per the algorithm specification.
 
 #### `is_valid(password, pw_hash)`
 

--- a/docs/crypto/buffer.md
+++ b/docs/crypto/buffer.md
@@ -118,9 +118,12 @@ data = BytesIO(b"data to hash")
 digest = sha512_hash(data)
 ```
 
-### `sha1_hash(buf)`
+### `sha1_hash(buf)` *(deprecated)*
 
 Compute SHA-1 hash of a buffer.
+
+**Deprecated:** This function emits a `DeprecationWarning` when called. SHA-1 is cryptographically broken. Use
+`sha256_hash()` or `sha512_hash()` instead.
 
 **Parameters:**
 
@@ -137,7 +140,7 @@ from rick.crypto import sha1_hash
 from io import BytesIO
 
 data = BytesIO(b"data to hash")
-digest = sha1_hash(data)
+digest = sha1_hash(data)  # emits DeprecationWarning
 ```
 
 **Security Warning:** SHA-1 is considered cryptographically broken and should not be used for security purposes. Use
@@ -169,11 +172,13 @@ digest = blake2_hash(data)
 
 ### `hash_buffer(method, buf)`
 
-Generic hash function that supports any hashlib algorithm.
+Hash function restricted to approved cryptographic algorithms.
+
+**Approved algorithms:** `sha256`, `sha384`, `sha512`, `blake2b`, `blake2s`
 
 **Parameters:**
 
-- `method` (str): Name of the hash algorithm (e.g., "sha256", "md5", "sha384")
+- `method` (str): Name of the hash algorithm (must be one of the approved algorithms)
 - `buf` (BytesIO): Buffer containing data to hash
 
 **Returns:**
@@ -182,7 +187,7 @@ Generic hash function that supports any hashlib algorithm.
 
 **Raises:**
 
-- `RuntimeError`: If the specified method is not available in hashlib
+- `ValueError`: If the specified method is not in the approved algorithms list
 
 **Example:**
 
@@ -198,8 +203,8 @@ sha256 = hash_buffer("sha256", data)
 # Use SHA-384
 sha384 = hash_buffer("sha384", data)
 
-# Use MD5 (not recommended for security)
-md5 = hash_buffer("md5", data)
+# Use BLAKE2b
+blake2 = hash_buffer("blake2b", data)
 ```
 
 ## File Hashing
@@ -674,10 +679,10 @@ from rick.crypto.buffer import hash_buffer
 from io import BytesIO
 
 try:
-    # Invalid hash method
-    hash_buffer("invalid_method", BytesIO(b"data"))
-except RuntimeError as e:
-    print(f"Invalid hash method: {e}")
+    # Unapproved hash method
+    hash_buffer("md5", BytesIO(b"data"))
+except ValueError as e:
+    print(f"Unapproved algorithm: {e}")
 
 # Ensure buffer is seekable
 data = BytesIO(b"data")

--- a/docs/resources/redis.md
+++ b/docs/resources/redis.md
@@ -204,12 +204,13 @@ CryptRedisCache(key, **kwargs)
 
 | Parameter | Type | Description                                          |
 |-----------|------|------------------------------------------------------|
-| `key`     | str  | 64-character encryption key (will be base64 encoded) |
+| `key`     | str  | Encryption key that must be exactly 64 bytes when UTF-8 encoded (will be base64 encoded) |
 
 **Additional Parameters:** All parameters from `RedisCache` are supported.
 
-**Important:** The encryption key must be exactly 64 characters long. The key is base64-encoded internally to create a
-Fernet256 key.
+**Important:** The encryption key must be exactly 64 bytes long when encoded as UTF-8. The key is base64-encoded
+internally to create a Fernet256 key. For ASCII keys, 64 characters equals 64 bytes; for multi-byte characters, ensure
+the byte length is correct.
 
 ### Generating Encryption Keys
 

--- a/docs/serializers/msgpack.md
+++ b/docs/serializers/msgpack.md
@@ -524,6 +524,9 @@ When deserializing MessagePack data:
 2. **Module Imports:** Dataclass and object reconstruction requires importing the original class. Ensure the module is
    available and safe.
 
+3. **Deserialization Depth Limit:** `unpackb()` enforces a maximum deserialization depth of 32 levels to prevent stack
+   overflow from deeply nested or crafted payloads. A `ValueError` is raised if the limit is exceeded.
+
 ## Limitations
 
 1. **Class Availability:** Custom classes and dataclasses must be importable at deserialization time

--- a/docs/validators/validator_list.md
+++ b/docs/validators/validator_list.md
@@ -42,8 +42,8 @@
 |---------|------------|-----------------------------------------------------------------|
 | between | min,max    | Value must be numeric between min and max; Floats are supported |
 | numeric |            | Value must be a numeral (digits only)                           |
-| decimal |            | Value must be a valid decimal numeral                           |
-| int     |            | Value must be a valid integer                                   |
+| decimal |            | Value must be a valid finite decimal numeral (rejects Infinity and NaN) |
+| int     |            | Value must be a valid integer (rejects booleans)                        |
 
 ## Network Validators
 

--- a/rick/base/di.py
+++ b/rick/base/di.py
@@ -1,6 +1,7 @@
 import functools
 import types
 from inspect import isclass
+from threading import Lock
 
 
 class Di:
@@ -10,6 +11,7 @@ class Di:
         """
         self._parent = di
         self._registry = {}  # internal dependency registry
+        self._lock = Lock()
 
     def register(self, name: str):
         """
@@ -64,7 +66,8 @@ class Di:
             # or if it is an object or callable, just store it
             self._registry[name] = item
         if replace:  # if replacing existing item, clear lru_cache
-            self.get.cache_clear()
+            with self._lock:
+                self.get.cache_clear()
 
     @functools.lru_cache(maxsize=None)
     def get(self, name: str):

--- a/rick/base/maploader.py
+++ b/rick/base/maploader.py
@@ -38,7 +38,7 @@ class MapLoader:
                 del self._map[name]
             if name in self._loaded.keys():
                 del self._loaded[name]
-        self.get.cache_clear()
+            self.get.cache_clear()
 
     def clear_loaded(self):
         """
@@ -47,7 +47,7 @@ class MapLoader:
         """
         with self._lock:
             self._loaded = {}
-        self.get.cache_clear()
+            self.get.cache_clear()
 
     def append(self, map: dict):
         """
@@ -88,29 +88,31 @@ class MapLoader:
             self._stack.append(name)
             path = self._map[name]
 
-        module_path, cls_name = path.rsplit(".", 1)
         try:
-            module = importlib.import_module(module_path)
-            cls = getattr(module, cls_name, None)
-            if cls is None:
+            module_path, cls_name = path.rsplit(".", 1)
+            try:
+                module = importlib.import_module(module_path)
+                cls = getattr(module, cls_name, None)
+                if cls is None:
+                    raise RuntimeError(
+                        "get(): cannot find class '%s' in module '%s'"
+                        % (cls_name, module_path)
+                    )
+
+            except ModuleNotFoundError:
                 raise RuntimeError(
-                    "get(): cannot find class '%s' in module '%s'"
-                    % (cls_name, module_path)
+                    "get(): mapped module '%s' not found when discovering path %s"
+                    % (module_path, path)
                 )
 
-        except ModuleNotFoundError:
+            obj = self.build(cls)
             with self._lock:
-                self._stack.remove(name)
-            raise RuntimeError(
-                "get(): mapped module '%s' not found when discovering path %s"
-                % (module_path, path)
-            )
-
-        obj = self.build(cls)
-        with self._lock:
-            self._loaded[name] = obj
-            self._stack.remove(name)
-        return obj
+                self._loaded[name] = obj
+            return obj
+        finally:
+            with self._lock:
+                if name in self._stack:
+                    self._stack.remove(name)
 
     def build(self, cls) -> object:
         """

--- a/rick/constants.py
+++ b/rick/constants.py
@@ -1,4 +1,4 @@
-RICK_VERSION = ["0", "8", "1"]
+RICK_VERSION = ["0", "8", "2"]
 
 
 def get_version():

--- a/rick/crypto/buffer.py
+++ b/rick/crypto/buffer.py
@@ -1,13 +1,18 @@
 import hashlib
+import warnings
 from io import BytesIO
+
+APPROVED_ALGORITHMS = {"sha256", "sha384", "sha512", "blake2b", "blake2s"}
 
 
 def hash_buffer(method, buf: BytesIO) -> str:
-    fn = getattr(hashlib, method)
-    if not callable(fn):
-        raise RuntimeError(
-            "hash_buffer(): invalid hashing method:  '{}'".format(method)
+    if method not in APPROVED_ALGORITHMS:
+        raise ValueError(
+            "hash_buffer(): algorithm '{}' not approved; use one of: {}".format(
+                method, ", ".join(sorted(APPROVED_ALGORITHMS))
+            )
         )
+    fn = getattr(hashlib, method)
     buf.seek(0)
     return fn(buf.read()).hexdigest()
 
@@ -18,6 +23,11 @@ def sha256_hash(buf: BytesIO) -> str:
 
 
 def sha1_hash(buf: BytesIO) -> str:
+    warnings.warn(
+        "sha1_hash() is deprecated: SHA-1 is cryptographically broken; use sha256_hash() or sha512_hash() instead",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     buf.seek(0)
     return hashlib.sha1(buf.read()).hexdigest()
 

--- a/rick/crypto/hasher/bcrypt.py
+++ b/rick/crypto/hasher/bcrypt.py
@@ -1,4 +1,3 @@
-import hashlib
 import hmac
 
 import bcrypt
@@ -23,7 +22,7 @@ class BcryptHasher(HasherInterface):
         if len(password) == 0:
             raise ValueError("hash(): empty password")
 
-        password = hashlib.sha256(password.encode("utf-8")).hexdigest().encode("utf-8")
+        password = password.encode("utf-8")
         salt = bcrypt.gensalt(rounds=self._rounds, prefix=self._prefix.encode("utf-8"))
 
         return bcrypt.hashpw(password, salt).decode("utf-8")
@@ -36,7 +35,7 @@ class BcryptHasher(HasherInterface):
         :return: True if the hash matches the supplied password
         """
         pw_hash = pw_hash.encode("utf-8")
-        password = hashlib.sha256(password.encode("utf-8")).hexdigest().encode("utf-8")
+        password = password.encode("utf-8")
 
         return hmac.compare_digest(bcrypt.hashpw(password, pw_hash), pw_hash)
 

--- a/rick/event/manager.py
+++ b/rick/event/manager.py
@@ -44,7 +44,7 @@ class EventManager:
         """
         with self._handler_lock:
             with self._stack_lock:
-                self._handlers = src.data
+                self._handlers = copy.deepcopy(src.data)
 
     def load_handlers(self, src: dict):
         """
@@ -188,57 +188,56 @@ class EventManager:
                 )
             self._stack.append(event_name)
 
-        with self._handler_lock:
-            evt = self._handlers[event_name]
-            priorities = list(evt.keys())
-            priorities.remove("handlers")
-            priorities.sort()
-            for p in priorities:
-                for handler in evt[p]:
-                    module_path, cls_name = handler.rsplit(".", 1)
-                    try:
-                        # try to locate function or class
-                        module = importlib.import_module(module_path)
-                        cls = getattr(module, cls_name, None)
-                        if cls is None:
-                            self._stack_remove(event_name)
+        try:
+            with self._handler_lock:
+                evt = self._handlers[event_name]
+                priorities = list(evt.keys())
+                priorities.remove("handlers")
+                priorities.sort()
+                for p in priorities:
+                    for handler in evt[p]:
+                        module_path, cls_name = handler.rsplit(".", 1)
+                        try:
+                            # try to locate function or class
+                            module = importlib.import_module(module_path)
+                            cls = getattr(module, cls_name, None)
+                            if cls is None:
+                                raise RuntimeError(
+                                    "dispatch(): cannot find class or function '%s' in module '%s'"
+                                    % (cls_name, module_path)
+                                )
+
+                        except ModuleNotFoundError:
                             raise RuntimeError(
-                                "dispatch(): cannot find class or function '%s' in module '%s'"
-                                % (cls_name, module_path)
+                                "dispatch(): mapped module '%s' not found when discovering path '%s'"
+                                % (module_path, handler)
                             )
 
-                    except ModuleNotFoundError:
-                        self._stack_remove(event_name)
-                        raise RuntimeError(
-                            "dispatch(): mapped module '%s' not found when discovering path '%s'"
-                            % (module_path, handler)
-                        )
+                        if isclass(cls) and issubclass(cls, EventHandler):
+                            # build object from class
+                            obj = cls(di)
 
-                    if isclass(cls) and issubclass(cls, EventHandler):
-                        # build object from class
-                        obj = cls(di)
+                            # check if event method handler exists
+                            obj_handler = getattr(obj, event_name, None)
+                            if obj_handler is None:
+                                raise RuntimeError(
+                                    "dispatch(): event handler for '%s' not found in '%s'"
+                                    % (event_name, handler)
+                                )
+                            obj_handler(**kwargs)
 
-                        # check if event method handler exists
-                        obj_handler = getattr(obj, event_name, None)
-                        if obj_handler is None:
+                        elif callable(cls) and not isclass(cls):
+                            # cls is a function
+                            fn_kwargs = dict(kwargs, event_name=event_name)
+                            cls(**fn_kwargs)
+
+                        else:
                             raise RuntimeError(
-                                "dispatch(): event handler for '%s' not found in '%s'"
-                                % (event_name, handler)
+                                "dispatch(): handler '%s' for event '%s' invalid or incompatible"
+                                % (handler, event_name)
                             )
-                        obj_handler(**kwargs)
-
-                    elif callable(cls) and not isclass(cls):
-                        # cls is a function
-                        fn_kwargs = dict(kwargs, event_name=event_name)
-                        cls(**fn_kwargs)
-
-                    else:
-                        raise RuntimeError(
-                            "dispatch(): handler '%s' for event '%s' invalid or incompatible"
-                            % (handler, event_name)
-                        )
-
-        self._stack_remove(event_name)
+        finally:
+            self._stack_remove(event_name)
         return True
 
     def _stack_remove(self, event_name):

--- a/rick/form/form.py
+++ b/rick/form/form.py
@@ -7,10 +7,10 @@ class Control:
     type = ""
     label = ""
     value = None
-    attributes = {}
-    options = {}
 
     def __init__(self, **kwargs):
+        self.attributes = {}
+        self.options = {}
         for k, v in kwargs.items():
             setattr(self, k, v)
 
@@ -43,7 +43,7 @@ class FieldSet:
         """
 
         if field_id in self.fields.keys():
-            raise RuntimeError("duplicated field id '%s'" % (id,))
+            raise RuntimeError("duplicated field id '%s'" % (field_id,))
 
         kwargs["type"] = field_type
         kwargs["label"] = self.translator.t(label)

--- a/rick/form/requestrecord.py
+++ b/rick/form/requestrecord.py
@@ -160,6 +160,15 @@ class RequestRecord:
         if valid_fields and valid_records:
             # set values for fields
             for field_name, field in self.fields.items():
+                # assign raw value (or filtered value) first
+                if field_name in data.keys():
+                    if field.filter is None:
+                        field.value = data[field_name]
+                    else:
+                        field.value = field.filter.transform(data[field_name])
+                else:
+                    field.value = None
+
                 # attempt to find a method called validator_<field_id>() in the current object
                 method_name = "_".join(["validator", field_name.replace("-", "_")])
                 custom_validator = getattr(self, method_name, None)
@@ -170,18 +179,10 @@ class RequestRecord:
                         # note: errors are added inside the custom validator method; at this point,
                         # there are no other errors, as valid_fields and valid_records is true
                         return False
-
-                if field_name in data.keys():
-                    if field.filter is None:
-                        field.value = data[field_name]
-                    else:
-                        field.value = field.filter.transform(data[field_name])
-                else:
-                    field.value = None
             return True
 
         # concat validation errors with record errors
-        self.errors = {**self.errors, **self.validator.get_errors()}
+        self.errors = {**self.validator.get_errors(), **self.errors}
         return False
 
     @deprecated("replaced by function get_errors()")

--- a/rick/resource/redis/redis.py
+++ b/rick/resource/redis/redis.py
@@ -143,9 +143,10 @@ class CryptRedisCache(RedisCache):
         if key is None:
             raise ValueError("Empty fernet encryption key")
 
-        if len(key) != 64:
+        key_bytes = key.encode("utf-8")
+        if len(key_bytes) != 64:
             raise ValueError("CryptRedis: key must be a 64 byte string")
-        key = base64.urlsafe_b64encode(key.encode("utf-8"))
+        key = base64.urlsafe_b64encode(key_bytes)
 
         super().__init__(**kwargs)
         self._crypt = Fernet256(key)

--- a/rick/resource/stream/multipart_reader.py
+++ b/rick/resource/stream/multipart_reader.py
@@ -98,6 +98,9 @@ class MultiPartReader:
         if length < 0:
             length = self.size
 
+        if offset + length > self.size:
+            length = self.size - offset
+
         ofs_current = 0
         ofs_end = offset + length
         for p in self.parts:

--- a/rick/serializer/msgpack/msgpack.py
+++ b/rick/serializer/msgpack/msgpack.py
@@ -217,6 +217,26 @@ def packb(obj: Any, **kwargs) -> bytes:
     return msgpack.packb(obj, default=default, use_bin_type=True, **kwargs)
 
 
+MAX_DESERIALIZATION_DEPTH = 32
+
+_deserialization_depth = 0
+
+
+def _depth_limited_ext_hook(code: int, data: bytes) -> Any:
+    global _deserialization_depth
+    _deserialization_depth += 1
+    try:
+        if _deserialization_depth > MAX_DESERIALIZATION_DEPTH:
+            raise ValueError(
+                "Maximum deserialization depth ({}) exceeded".format(
+                    MAX_DESERIALIZATION_DEPTH
+                )
+            )
+        return ext_hook(code, data)
+    finally:
+        _deserialization_depth -= 1
+
+
 def unpackb(packed: bytes, **kwargs) -> Any:
     """
     Deserialize msgpack bytes to Python object with custom type support.
@@ -228,7 +248,9 @@ def unpackb(packed: bytes, **kwargs) -> Any:
     Returns:
         Deserialized Python object
     """
-    return msgpack.unpackb(packed, ext_hook=ext_hook, raw=False, **kwargs)
+    global _deserialization_depth
+    _deserialization_depth = 0
+    return msgpack.unpackb(packed, ext_hook=_depth_limited_ext_hook, raw=False, **kwargs)
 
 
 def pack(obj: Any, stream, **kwargs) -> None:

--- a/rick/util/datetime.py
+++ b/rick/util/datetime.py
@@ -2,4 +2,4 @@ import datetime
 
 
 def iso8601_now():
-    return datetime.datetime.now().astimezone().isoformat()
+    return datetime.datetime.now(datetime.timezone.utc).isoformat()

--- a/rick/util/object.py
+++ b/rick/util/object.py
@@ -15,13 +15,13 @@ def get_attribute_names(object) -> List:
 
 
 def is_object(param):
-    if not param:
+    if param is None:
         return False
-    if isinstance(param, object):
-        t = str(getattr(param, "__class__"))
-        t = t.split("'")[1::2]
-        return t[0] not in ["type", "str"]
-    return False
+    if isinstance(param, (str, int, float, bool, bytes, list, tuple, dict, set)):
+        return False
+    if isinstance(param, type):
+        return False
+    return hasattr(param, "__dict__")
 
 
 def full_name(obj):

--- a/rick/validator/rules/misc.py
+++ b/rick/validator/rules/misc.py
@@ -223,6 +223,9 @@ class ListLen(Rule):
         if type(value) in (list, tuple):
             value_len = len(value)
 
+        if not options:
+            return True, ""
+
         if len(options) >= 2:
             min = int(options[0])
             max = int(options[1])

--- a/rick/validator/rules/net.py
+++ b/rick/validator/rules/net.py
@@ -66,9 +66,7 @@ class IP(Rule):
 @registry.register_cls(name="fqdn")
 class Fqdn(Rule):
     MSG_ERROR = "invalid domain name"
-    WHITELIST = [
-        "localhost",
-    ]
+    WHITELIST = []
     REGEX = re.compile(
         # max length for domain name labels is 63 characters per RFC 1034
         r"((?:[A-Z0-9](?:[A-Z0-9-]{0,61}[A-Z0-9])?\.)+)" r"(?:[A-Z0-9-]{2,63}(?<!-))\Z",
@@ -116,8 +114,12 @@ class Email(Rule):
             return False, self.error_message(error_msg, translator)
         user, domain = toks
 
+        # RFC 5321 length limits
+        if len(user) > 64 or len(domain) > 255:
+            return False, self.error_message(error_msg, translator)
+
         # username
-        if not self.REGEX.match(user):
+        if not user or not self.REGEX.match(user):
             return False, self.error_message(error_msg, translator)
 
         # domain

--- a/rick/validator/rules/numeric.py
+++ b/rick/validator/rules/numeric.py
@@ -16,6 +16,7 @@ class Between(Rule):
     def validate(
         self, value, options: list = None, error_msg=None, translator: Translator = None
     ):
+        options = self.parse_options(options)
         value = cast_float(value)
         if value is not None and float(options[1]) >= value >= float(options[0]):
             return True, ""
@@ -54,7 +55,9 @@ class Decimal(Rule):
         if error_msg is None:
             error_msg = self.MSG_ERROR
         try:
-            decimal.Decimal(value)
+            d = decimal.Decimal(value)
+            if not d.is_finite():
+                return False, self.error_message(error_msg, translator)
             return True, ""
         except TypeError:
             return False, self.error_message(error_msg, translator)
@@ -69,6 +72,9 @@ class IntRule(Rule):
     def validate(
         self, value, options: list = None, error_msg=None, translator: Translator = None
     ):
+        if isinstance(value, bool):
+            return False, self.error_message(error_msg, translator)
+
         if type(value) is int:
             return True, ""
 

--- a/tests/crypto/hasher/test_bcrypt.py
+++ b/tests/crypto/hasher/test_bcrypt.py
@@ -5,9 +5,9 @@ from rick.crypto.hasher.bcrypt import BcryptHasher
 class TestBcryptHasher:
     rounds = 8  # lower round count for testing purposes
     valid_passwords = {
-        "12345678": "$2b$08$Y1nUUzX0ZikQi0hSoGZXlODlQYUnF6SnyZIrFIVUZ2jgnIun/mDOO",
-        "sdktrqjkl4dskl": "$2b$08$5McEp4dvSohJdxnWONX3JOYJ8P6TQK6qosOAz0CSAkOr5T647r5G2",
-        "423FDS$&dYdcWs/dAS5": "$2b$08$WiCcKN2HtPzjH58dNEIcf.o/NoFKCZDJIr0c/Fqy1jKiknpvIuvTC",
+        "12345678": "$2b$08$Ex7KPIGtDml1hzlpSjlZv.S4F6ToP1DD1L8bylO6i6v8U9OmCU.IG",
+        "sdktrqjkl4dskl": "$2b$08$2A/LDGvtHdhayOEqLXThaOM5jq.IcvGI18JBy/xjQsxlOj8MlsXiO",
+        "423FDS$&dYdcWs/dAS5": "$2b$08$yjsNQsYLFMHrCZXAKbdItObDtMjScF/GViqyGMb4zP3EggvxRAkR2",
     }
 
     invalid_passwords = [


### PR DESCRIPTION
Fix 21 issues across crypto, validators, forms, events, DI, serializers and utilities. Key changes include removing bcrypt SHA-256 pre-hashing, adding hash_buffer algorithm whitelist, depth-limited msgpack deserialization, thread-safety fixes for Di/MapLoader, stack leak prevention in EventManager/MapLoader, and multiple validator corrections.

## Summary by Sourcery

Harden security around cryptography, deserialization, and validation while fixing correctness and concurrency issues across events, DI, forms, and utilities for the 0.8.2 release.

Bug Fixes:
- Prevent EventManager and MapLoader internal stacks from leaking on exceptions during dispatch and lazy loading.
- Ensure EventManager wakeup uses an isolated copy of handler state to avoid unintended mutation.
- Fix Di and MapLoader cache clearing to occur under locks, preventing race conditions with concurrent access.
- Correct RequestRecord so field values are populated before custom validators run and record-level errors take precedence when merging errors.
- Adjust CryptRedisCache to validate key length in bytes (UTF-8) rather than characters for proper multi-byte handling.
- Clamp MultiPartReader reads to stream bounds to avoid reading past the end of the underlying stream.
- Fix Form Control/FieldSet to avoid shared mutable default attributes and correct the duplicate field error message identifier.
- Update iso8601_now() to use an explicit UTC timezone representation instead of local-time conversion.

Enhancements:
- Restrict hash_buffer() to a curated set of modern algorithms and deprecate sha1_hash() while documenting safer alternatives.
- Remove bcrypt SHA-256 pre-hashing so passwords are hashed directly with bcrypt, aligning with standard expectations and docs.
- Add depth-limited msgpack deserialization to mitigate stack overflow from excessively nested or crafted payloads.
- Harden is_object() type detection with explicit exclusions for primitives and types.
- Tighten validators: Between now normalizes options, Decimal rejects non-finite values, IntRule rejects booleans, ListLen gracefully handles missing options, Email enforces RFC 5321 limits, and FQDN no longer whitelists localhost.
- Clarify crypto, Redis, bcrypt, msgpack, and validator documentation to reflect the new security constraints and behaviors.
- Bump library version to 0.8.2 and update changelog links for the new release.

Documentation:
- Document deprecation and safe alternatives for sha1_hash(), and restrict hash_buffer() docs to approved algorithms with updated examples.
- Clarify CryptRedisCache key length requirements in bytes for UTF-8 and explain implications for multi-byte characters.
- Describe msgpack deserialization depth limits and associated error behavior.
- Update validator docs for decimal and int rules to capture new rejection semantics.
- Revise bcrypt documentation to remove SHA-256 pre-hashing guidance and explain bcrypt length truncation behavior.

Tests:
- Update bcrypt hasher tests with new hash vectors reflecting direct bcrypt hashing without pre-hashing.